### PR TITLE
feature/157 keep history of cat output runs

### DIFF
--- a/.github/workflows/release-mac-os-x.yml
+++ b/.github/workflows/release-mac-os-x.yml
@@ -38,6 +38,12 @@ jobs:
           # Navigate to dist directory
           cd dist
 
+          # Fix code signing for macOS (Ad-hoc signing with entitlements)
+          # This is critical for Apple Silicon (M1/M2) support
+          echo "Applying ad-hoc code signature to bundled binaries..."
+          find appdynamics -name "*.so" -o -name "*.dylib" -o -name "Python" | xargs codesign --force -s - --preserve-metadata=identifier,entitlements
+          codesign --force --deep -s - appdynamics/config-assessment-tool/*/config-assessment-tool
+
           # Determine the name of the PyInstaller created directory (e.g., 'config-assessment-tool')
           # Assumes PyInstaller creates a single top-level directory inside appdynamics/
           BUNDLE_DIR_PATH=$(find appdynamics -maxdepth 1 -mindepth 1 -type d)

--- a/backend/Dockerfile-ubuntu
+++ b/backend/Dockerfile-ubuntu
@@ -69,6 +69,9 @@ COPY Pipfile.lock .
 
 RUN BUNDLE_VERSION=`cat VERSION`
 
+# Force cache invalidation to ensure we don't use old layers with pipx pyinstaller
+ENV CACHE_BUSTER=20260204
+
 # Install pipx, then use it to install pipenv and pyinstaller
 # All Python-related commands now use the specific /usr/local/bin/python3.12 path
 # and rely on the ENV PATH for pipx to find pipenv/pyinstaller.


### PR DESCRIPTION
- **UI and functional changes**
- **refactor**
- **refactor to edit file in-line**
- **pull prior fix and fix UI**
- **check api client username for access**
- **refactored out unused classes**
- **refactoring and UI improvements**
- **latest refactorings**
- **up version for now, one bump**
- **test out trigger**
- **transfer dev to fork**
- **before major docker image refactoring with combined docker image.  after this commit will combine front/backends into one**
- **refactored into one container.**
- **introduce make**
- **working docker for ui and backend with proper logging and working shell wrapper file**
- **running from source works as well(ie. no docker)**
- **modal pops up ok with log content. need to tune**
- **modal window tuned.**
- **all works except cat.sh running from source**
- **unified docker images now**
- **tune code packaging. introduce wrapper script.  tune single image startup**
- **tune scrit**
- **restart docker image publishing**
- **refactor to ease starting cat**
- **properly clean up after script finalization**
- **manual trigger**
- **set repo dynamically**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **base image fix**
- **base image fix**
- **base image fix, install required packages**
- **base image fix, install required packages**
- **base image fix, install required packages**
- **base image fix, install required packages**
- **upgrade python, packages, tune UI completion logic and modal window**
- **new pptx enhanced report added and old one depricated.**
- **UI and functional changes**
- **refactor**
- **refactor to edit file in-line**
- **pull prior fix and fix UI**
- **check api client username for access**
- **refactored out unused classes**
- **refactoring and UI improvements**
- **latest refactorings**
- **up version for now, one bump**
- **test out trigger**
- **transfer dev to fork**
- **before major docker image refactoring with combined docker image.  after this commit will combine front/backends into one**
- **refactored into one container.**
- **introduce make**
- **working docker for ui and backend with proper logging and working shell wrapper file**
- **running from source works as well(ie. no docker)**
- **modal pops up ok with log content. need to tune**
- **modal window tuned.**
- **all works except cat.sh running from source**
- **unified docker images now**
- **tune code packaging. introduce wrapper script.  tune single image startup**
- **tune scrit**
- **restart docker image publishing**
- **refactor to ease starting cat**
- **properly clean up after script finalization**
- **manual trigger**
- **set repo dynamically**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **base image fix**
- **base image fix**
- **base image fix, install required packages**
- **base image fix, install required packages**
- **base image fix, install required packages**
- **base image fix, install required packages**
- **upgrade python, packages, tune UI completion logic and modal window**
- **new pptx enhanced report added and old one depricated.**
- **smoother startup**
- **tune packaging**
- **up python**
- **up python and workflow dependencies**
- **up python and workflow dependencies**
- **up python and workflow dependencies**
- **multi-arch docker image**
- **multi-arch docker image**
- **multi-arch docker image**
- **multi-arch docker image**
- **disable test workflow fo rnow**
- **Disable tests workflow and fix ubuntu bundle build**
- **Disable tests workflow and fix ubuntu bundle build**
- **Disable tests workflow and fix ubuntu bundle build**
- **Disable tests workflow and fix ubuntu bundle build**
- **Fix PyInstaller execution in Ubuntu Dockerfile to use global environment**
- **Fix Windows multi-arch build: Use native docker build instead of buildx**
- **Fix Ubuntu build: Force cache invalidation to remove pipx pyinstaller layer**
