### PR TITLE
feature/157 keep history of cat output runs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,8 @@ openpyxl = ">=3.1.0"
 uplink = ">=0.9.7"
 # CHANGED: 3.13.3 doesn't exist. Setting to * allows the latest compatible version.
 aiohttp = "*"
-docker = "==5.0.2"
+# docker = ">=5.0.3"
+docker = "*"
 # CHANGED: 4.0b1 is a beta. 5.x is stable and better for 3.12
 tzlocal = ">=4.2"
 streamlit = "1.37.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "460ccb47fc04dc1330339fda289c287dcb71643f28a88ca3ea2bdf9779acc270"
+            "sha256": "f75b43985b2b0158abbfe02299fc2a333774f78dab93a0396dc3d0102d3b2ccf"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -346,12 +346,12 @@
         },
         "docker": {
             "hashes": [
-                "sha256:21ec4998e90dff7a7aaaa098ca8d839c7de412b89e6f6c30908372d58fecf663",
-                "sha256:9b17f0723d83c1f3418d2aa17bf90b24dbe97deda06208dd4262fa30a6ee87eb"
+                "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c",
+                "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
-            "version": "==5.0.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==7.1.0"
         },
         "entrypoints": {
             "hashes": [
@@ -1721,14 +1721,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==2.6.3"
-        },
-        "websocket-client": {
-            "hashes": [
-                "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98",
-                "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==1.9.0"
         },
         "xlsxwriter": {
             "hashes": [


### PR DESCRIPTION
- **UI and functional changes**
- **refactor**
- **refactor to edit file in-line**
- **pull prior fix and fix UI**
- **check api client username for access**
- **refactored out unused classes**
- **refactoring and UI improvements**
- **latest refactorings**
- **up version for now, one bump**
- **test out trigger**
- **transfer dev to fork**
- **before major docker image refactoring with combined docker image.  after this commit will combine front/backends into one**
- **refactored into one container.**
- **introduce make**
- **working docker for ui and backend with proper logging and working shell wrapper file**
- **running from source works as well(ie. no docker)**
- **modal pops up ok with log content. need to tune**
- **modal window tuned.**
- **all works except cat.sh running from source**
- **unified docker images now**
- **tune code packaging. introduce wrapper script.  tune single image startup**
- **tune scrit**
- **restart docker image publishing**
- **refactor to ease starting cat**
- **properly clean up after script finalization**
- **manual trigger**
- **set repo dynamically**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **base image fix**
- **base image fix**
- **base image fix, install required packages**
- **base image fix, install required packages**
- **base image fix, install required packages**
- **base image fix, install required packages**
- **upgrade python, packages, tune UI completion logic and modal window**
- **new pptx enhanced report added and old one depricated.**
- **UI and functional changes**
- **refactor**
- **refactor to edit file in-line**
- **pull prior fix and fix UI**
- **check api client username for access**
- **refactored out unused classes**
- **refactoring and UI improvements**
- **latest refactorings**
- **up version for now, one bump**
- **test out trigger**
- **transfer dev to fork**
- **before major docker image refactoring with combined docker image.  after this commit will combine front/backends into one**
- **refactored into one container.**
- **introduce make**
- **working docker for ui and backend with proper logging and working shell wrapper file**
- **running from source works as well(ie. no docker)**
- **modal pops up ok with log content. need to tune**
- **modal window tuned.**
- **all works except cat.sh running from source**
- **unified docker images now**
- **tune code packaging. introduce wrapper script.  tune single image startup**
- **tune scrit**
- **restart docker image publishing**
- **refactor to ease starting cat**
- **properly clean up after script finalization**
- **manual trigger**
- **set repo dynamically**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **windows docker images**
- **base image fix**
- **base image fix**
- **base image fix, install required packages**
- **base image fix, install required packages**
- **base image fix, install required packages**
- **base image fix, install required packages**
- **upgrade python, packages, tune UI completion logic and modal window**
- **new pptx enhanced report added and old one depricated.**
- **smoother startup**
- **tune packaging**
- **up python**
- **up python and workflow dependencies**
- **up python and workflow dependencies**
- **up python and workflow dependencies**
- **multi-arch docker image**
- **multi-arch docker image**
- **multi-arch docker image**
- **multi-arch docker image**
- **disable test workflow fo rnow**
- **Disable tests workflow and fix ubuntu bundle build**
- **Disable tests workflow and fix ubuntu bundle build**
- **Disable tests workflow and fix ubuntu bundle build**
- **Disable tests workflow and fix ubuntu bundle build**
- **Fix PyInstaller execution in Ubuntu Dockerfile to use global environment**
- **Fix Windows multi-arch build: Use native docker build instead of buildx**
- **Fix Ubuntu build: Force cache invalidation to remove pipx pyinstaller layer**
- **Fix Ubuntu build: Force cache invalidation to remove pipx pyinstaller layer**
